### PR TITLE
fix(aws-android-sdk-transcribe): escape doc comment correctly

### DIFF
--- a/aws-android-sdk-transcribe/src/main/java/com/amazonaws/services/transcribe/model/ListTagsForResourceRequest.java
+++ b/aws-android-sdk-transcribe/src/main/java/com/amazonaws/services/transcribe/model/ListTagsForResourceRequest.java
@@ -27,7 +27,7 @@ public class ListTagsForResourceRequest extends AmazonWebServiceRequest implemen
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      */
     private String resourceArn;
 
@@ -36,7 +36,7 @@ public class ListTagsForResourceRequest extends AmazonWebServiceRequest implemen
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @return <p>Lists all tags associated with a given Amazon Resource Name (ARN).</p>
      */
@@ -49,7 +49,7 @@ public class ListTagsForResourceRequest extends AmazonWebServiceRequest implemen
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @param resourceArn <p>Lists all tags associated with a given Amazon Resource Name (ARN).</p>
      */
@@ -64,7 +64,7 @@ public class ListTagsForResourceRequest extends AmazonWebServiceRequest implemen
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @param resourceArn <p>Lists all tags associated with a given Amazon Resource Name (ARN).</p>
      *

--- a/aws-android-sdk-transcribe/src/main/java/com/amazonaws/services/transcribe/model/ListTagsForResourceResult.java
+++ b/aws-android-sdk-transcribe/src/main/java/com/amazonaws/services/transcribe/model/ListTagsForResourceResult.java
@@ -23,7 +23,7 @@ public class ListTagsForResourceResult implements Serializable {
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      */
     private String resourceArn;
 
@@ -37,7 +37,7 @@ public class ListTagsForResourceResult implements Serializable {
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @return <p>Lists all tags associated with the given Amazon Resource Name (ARN).</p>
      */
@@ -50,7 +50,7 @@ public class ListTagsForResourceResult implements Serializable {
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @param resourceArn <p>Lists all tags associated with the given Amazon Resource Name (ARN).</p>
      */
@@ -65,7 +65,7 @@ public class ListTagsForResourceResult implements Serializable {
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @param resourceArn <p>Lists all tags associated with the given Amazon Resource Name (ARN).</p>
      *

--- a/aws-android-sdk-transcribe/src/main/java/com/amazonaws/services/transcribe/model/TagResourceRequest.java
+++ b/aws-android-sdk-transcribe/src/main/java/com/amazonaws/services/transcribe/model/TagResourceRequest.java
@@ -27,7 +27,7 @@ public class TagResourceRequest extends AmazonWebServiceRequest implements Seria
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      */
     private String resourceArn;
 
@@ -41,7 +41,7 @@ public class TagResourceRequest extends AmazonWebServiceRequest implements Seria
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @return <p>The Amazon Resource Name (ARN) of the Amazon Transcribe resource you want to tag.</p>
      */
@@ -54,7 +54,7 @@ public class TagResourceRequest extends AmazonWebServiceRequest implements Seria
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @param resourceArn <p>The Amazon Resource Name (ARN) of the Amazon Transcribe resource you want to tag.</p>
      */
@@ -69,7 +69,7 @@ public class TagResourceRequest extends AmazonWebServiceRequest implements Seria
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @param resourceArn <p>The Amazon Resource Name (ARN) of the Amazon Transcribe resource you want to tag.</p>
      *

--- a/aws-android-sdk-transcribe/src/main/java/com/amazonaws/services/transcribe/model/UntagResourceRequest.java
+++ b/aws-android-sdk-transcribe/src/main/java/com/amazonaws/services/transcribe/model/UntagResourceRequest.java
@@ -27,7 +27,7 @@ public class UntagResourceRequest extends AmazonWebServiceRequest implements Ser
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      */
     private String resourceArn;
 
@@ -41,7 +41,7 @@ public class UntagResourceRequest extends AmazonWebServiceRequest implements Ser
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @return <p>The Amazon Resource Name (ARN) of the Amazon Transcribe resource you want to remove tags from.</p>
      */
@@ -54,7 +54,7 @@ public class UntagResourceRequest extends AmazonWebServiceRequest implements Ser
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @param resourceArn <p>The Amazon Resource Name (ARN) of the Amazon Transcribe resource you want to remove tags from.</p>
      */
@@ -69,7 +69,7 @@ public class UntagResourceRequest extends AmazonWebServiceRequest implements Ser
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>1 - 1011<br/>
-     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]*/[0-9a-zA-Z._-]+<br/>
+     * <b>Pattern: </b>arn:aws(-[^:]+)?:transcribe:[a-zA-Z0-9-]*:[0-9]{12}:[a-zA-Z-]{@literal *}/[0-9a-zA-Z._-]+<br/>
      *
      * @param resourceArn <p>The Amazon Resource Name (ARN) of the Amazon Transcribe resource you want to remove tags from.</p>
      *


### PR DESCRIPTION
using `literal` tag